### PR TITLE
Replace 'run build tasks' with 'run tasks' in VS Code keybindings

### DIFF
--- a/VS Code/keybindings.json
+++ b/VS Code/keybindings.json
@@ -9,13 +9,17 @@
     "command": "workbench.action.tasks.reRunTask"
   },
   {
+    "key": "shift+cmd+/",
+    "command": "workbench.action.terminal.new",
+    "when": "terminalProcessSupported || terminalWebExtensionContributedProfile"
+  },
+  {
     "key": "shift+cmd+b",
     "command": "-workbench.action.tasks.build",
     "when": "taskCommandsRegistered"
   },
   {
-    "key": "shift+cmd+/",
-    "command": "workbench.action.terminal.new",
-    "when": "terminalProcessSupported || terminalWebExtensionContributedProfile"
+    "key": "shift+cmd+b",
+    "command": "workbench.action.tasks.runTask"
   }
 ]


### PR DESCRIPTION
Replace 'run build tasks' with 'run tasks' in VS Code keybindings.